### PR TITLE
fix: update edit instruction text

### DIFF
--- a/src/components/AddTasks.jsx
+++ b/src/components/AddTasks.jsx
@@ -39,7 +39,7 @@ const AddTasks = ({ handleTaskAddition, tasks }) => {
             <div className='warning' style={tasks.length > 0 ? { display: 'flex' } : {}}>
                 <div className='info-container'>
                     <ion-icon name="alert-circle-outline" className="exclamation" size="large"></ion-icon>
-                    <p>When a task is <span className='complete'>completed</span> you can <span className='delete'>delete</span> it, <span className='edit'>DoubleClick</span> the Task you want to <span className='edit'>Edit</span>.</p>
+                    <p>When a task is <span className='complete'>completed</span> you can <span className='delete'>delete</span> it, <span className='edit'>double-click</span> the Task you want to <span className='edit'>Edit</span>.</p>
                 </div>
             </div>
         </>


### PR DESCRIPTION
## Summary
- show double-click as the edit action hint in AddTasks component

## Testing
- `npm run build`
- `grep -R -n -o "double-click" dist`


------
https://chatgpt.com/codex/tasks/task_e_68a6272908f08333a66ff541b85de8dd